### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+   branches: [ main, develop ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Potential fix for [https://github.com/zemin-piao/spark-history-server-rs/security/code-scanning/3](https://github.com/zemin-piao/spark-history-server-rs/security/code-scanning/3)

To fix this issue, explicitly set the `permissions` block in the workflow YAML to grant the least privilege needed. Since neither job requires anything beyond basic code checkout and typical test/build steps, they only need read access to contents—i.e., `contents: read`. This can be added to the workflow root (to apply to all jobs), or to each job individually for finer control. The best approach here is to add at the root level (after the `name:` and before `env:`), to cover all jobs unless they override. This does not change any workflow semantics except to reduce the GITHUB_TOKEN scope. Only lines at the root need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
